### PR TITLE
HeaderBar: Remove unused property

### DIFF
--- a/src/Widgets/HeaderBar.ui
+++ b/src/Widgets/HeaderBar.ui
@@ -28,8 +28,6 @@
 
 	<child>
 		<object class="HdyHeaderBar" id="_header_bar">
-			<property name="show-title-buttons">True</property>
-
 			<style>
 				<class name="titlebar" />
 			</style>


### PR DESCRIPTION
It appears show-title-buttons is no longer being used