### PR TITLE
ci: fixes and improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,5 +44,6 @@ jobs:
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           manifest-path: build-aux/app.drey.Replay.Devel.json
+          build-bundle: false
           cache-key: flatpak-builder-${{ github.sha }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
       options: --privileged
 
     strategy:
+      max-parallel: 1
       matrix: { arch: [x86_64, aarch64] }
       fail-fast: false
 
@@ -57,15 +58,23 @@ jobs:
           arch: ${{ matrix.arch }}
           gpg-sign: ${{ steps.gpg.outputs.keyid }}
 
-      - name: Push update
-        env:
-          ARCH: ${{ matrix.arch }}
-          REPO_URL: https://${{ secrets.GITHUB_TOKEN }}@github.com/nahuelwexd/replay-nightly.git
-        run: |
-          git clone $REPO_URL
+      - name: Checkout replay-nightly repo
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: nahuelwexd/replay-nightly
+          path: replay-nightly
 
+      - name: Commit update
+        env: { ARCH: ${{ matrix.arch }} }
+        run: |
           flatpak build-commit-from --src-repo=repo replay-nightly app/app.drey.Replay.Devel/$ARCH/master
           flatpak build-commit-from --src-repo=repo replay-nightly runtime/app.drey.Replay.Devel.Debug/$ARCH/master
 
-          cd replay-nightly
-          git add . && git commit --author=Nah -m "Update app.drey.Replay.Devel" && git push $REPO_URL main
+      - name: Push update
+        uses: EndBug/add-and-commit@v9.1.3
+        with:
+          commit: --amend
+          cwd: replay-nightly
+          default_author: github_actions
+          message: Update app.drey.Replay.Devel
+          push: --force origin main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,7 @@ jobs:
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           manifest-path: build-aux/app.drey.Replay.Devel.json
+          build-bundle: false
           cache-key: flatpak-builder-${{ github.sha }}
           arch: ${{ matrix.arch }}
           gpg-sign: ${{ steps.gpg.outputs.keyid }}


### PR DESCRIPTION
- Disable bundle exporting since it is not necessary
- Split the update push step into multiple, plus use existing actions when possible