### PR TITLE
http-error: improve HttpError creation

### DIFF
--- a/src/App.vala
+++ b/src/App.vala
@@ -34,7 +34,7 @@ sealed class Rpy.App : Adw.Application {
         base.startup ();
 
         Environment.set_application_name ("Replay");
-        this.style_manager.color_scheme = Adw.ColorScheme.PREFER_DARK;
+        this.style_manager.color_scheme = PREFER_DARK;
 
         this.add_action_entries ({
             { "about", this.show_about_window },
@@ -58,7 +58,7 @@ sealed class Rpy.App : Adw.Application {
             // TRANSLATORS: Put your credits here
             translator_credits  = _("translator-credits"),
             copyright           = "© 2023 Nahuel Gomez",
-            license_type        = Gtk.License.GPL_3_0,
+            license_type        = GPL_3_0,
         };
 
         about_window.present ();

--- a/src/Errors/HttpError.vala
+++ b/src/Errors/HttpError.vala
@@ -18,46 +18,39 @@ errordomain Rpy.HttpError {
     public static HttpError from_status_code (Soup.Status status_code, GJson.Node json) {
         var server_error_message = "no server error message";
 
-        var error_object = json.as_object ();
-        if (error_object.has_key ("error"))
-            server_error_message = error_object["error"].as_string ();
+        if (json.node_type == OBJECT && json["error"].node_type == STRING)
+            server_error_message = json["error"].as_string ();
+
+        var reason_phrase = Soup.Status.get_phrase (status_code);
+        var error_message = @"$reason_phrase: $server_error_message";
 
         switch (status_code) {
-            case BAD_REQUEST:
-                return new HttpError.BAD_REQUEST ("%s: %s",
-                    Soup.Status.get_phrase (status_code), server_error_message);
+            case Soup.Status.BAD_REQUEST:
+                return new HttpError.BAD_REQUEST (error_message);
 
-            case UNAUTHORIZED:
-                return new HttpError.UNAUTHORIZED ("%s: %s",
-                    Soup.Status.get_phrase (status_code), server_error_message);
+            case Soup.Status.CONFLICT:
+                return new HttpError.CONFLICT (error_message);
 
-            case FORBIDDEN:
-                return new HttpError.FORBIDDEN ("%s: %s",
-                    Soup.Status.get_phrase (status_code), server_error_message);
+            case Soup.Status.FORBIDDEN:
+                return new HttpError.FORBIDDEN (error_message);
 
-            case NOT_FOUND:
-                return new HttpError.NOT_FOUND ("%s: %s",
-                    Soup.Status.get_phrase (status_code), server_error_message);
+            case Soup.Status.INTERNAL_SERVER_ERROR:
+                return new HttpError.INTERNAL_SERVER_ERROR (error_message);
 
-            case REQUEST_TIMEOUT:
-                return new HttpError.REQUEST_TIMEOUT ("%s: %s",
-                    Soup.Status.get_phrase (status_code), server_error_message);
+            case Soup.Status.NOT_FOUND:
+                return new HttpError.NOT_FOUND (error_message);
 
-            case CONFLICT:
-                return new HttpError.CONFLICT ("%s: %s",
-                    Soup.Status.get_phrase (status_code), server_error_message);
+            case Soup.Status.REQUEST_TIMEOUT:
+                return new HttpError.REQUEST_TIMEOUT (error_message);
 
-            case INTERNAL_SERVER_ERROR:
-                return new HttpError.INTERNAL_SERVER_ERROR ("%s: %s",
-                    Soup.Status.get_phrase (status_code), server_error_message);
+            case Soup.Status.SERVICE_UNAVAILABLE:
+                return new HttpError.SERVICE_UNAVAILABLE (error_message);
 
-            case SERVICE_UNAVAILABLE:
-                return new HttpError.SERVICE_UNAVAILABLE ("%s: %s",
-                    Soup.Status.get_phrase (status_code), server_error_message);
+            case Soup.Status.UNAUTHORIZED:
+                return new HttpError.UNAUTHORIZED (error_message);
 
             default:
-                return new HttpError.UNKNOWN ("Unknown error: %s",
-                    server_error_message);
+                return new HttpError.UNKNOWN (@"Unknown error: $server_error_message");
         }
     }
 }

--- a/src/Features/Trends/TrendsView.vala
+++ b/src/Features/Trends/TrendsView.vala
@@ -14,7 +14,7 @@ sealed class Rpy.TrendsView : Adw.NavigationPage {
 
     [GtkCallback]
     private string state_to_nick (ViewModelState state) {
-        var local_state = state == ViewModelState.INITIAL
+        var local_state = state == INITIAL
             ? ViewModelState.IN_PROGRESS
             : state;
 


### PR DESCRIPTION
Add more checks before pulling the server error message, separate the framing of the error message for clarity, and use the full qualifier of Soup status codes to avoid collision with error codes from the HttpError domain