### PR TITLE
app-window: set minimum size

### DIFF
--- a/src/AppWindow.blp
+++ b/src/AppWindow.blp
@@ -5,6 +5,8 @@ template $RpyAppWindow : Adw.ApplicationWindow {
   title: 'Replay';
   default-width: 1020;
   default-height: 720;
+  width-request: 360;
+  height-request: 294;
 
   Adw.NavigationView _navigation_view {}
 }


### PR DESCRIPTION
This is the minimum size that apps must have to look good on Linux phones.